### PR TITLE
Grafana dashboard improvements

### DIFF
--- a/chart/saml-exporter/dashboard.json
+++ b/chart/saml-exporter/dashboard.json
@@ -2049,6 +2049,7 @@
   },
   "timepicker": {},
   "timezone": "",
+  "uid": "d760c5ff-a381-4efa-b78e-4f1ef3f8f9c7",
   "title": "SAML Metadata",
   "weekStart": ""
 }

--- a/chart/saml-exporter/dashboard.json
+++ b/chart/saml-exporter/dashboard.json
@@ -1129,7 +1129,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "RVra6BSnk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1206,7 +1206,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "RVra6BSnk"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(rate(http_client_requests_total{job=~\".*/saml-exporter\"}[$__rate_interval])) by (code, host)",

--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -2049,6 +2049,7 @@
   },
   "timepicker": {},
   "timezone": "",
+  "uid": "d760c5ff-a381-4efa-b78e-4f1ef3f8f9c7",
   "title": "SAML Metadata",
   "weekStart": ""
 }

--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -1129,7 +1129,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "RVra6BSnk"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1206,7 +1206,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "RVra6BSnk"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(rate(http_client_requests_total{job=~\".*/saml-exporter\"}[$__rate_interval])) by (code, host)",


### PR DESCRIPTION
## Current situation
The Grafana dashboard has a static datasource ID reference in one panel and changes its UID on every deployment.

## Proposal
Use the datasource variable everywhere and set any static UID for the dashboard to enable persistent links.
